### PR TITLE
Clarify comments about application config.

### DIFF
--- a/config/application.js
+++ b/config/application.js
@@ -1,12 +1,12 @@
 /* Exports a function which returns an object that overrides the default &
  *   plugin grunt configuration object.
  *
- * You can familiarize yourself with Lineman's defaults by checking out:
+ * You can familiarize yourself with Lineman's defaults by looking at:
  *
  *   - https://github.com/linemanjs/lineman/blob/master/config/application.coffee
  *   - https://github.com/linemanjs/lineman/blob/master/config/plugins
  *
- * You can also ask Lineman's about config from the command line:
+ * You can also ask about Lineman's config from the command line:
  *
  *   $ lineman config #=> to print the entire config
  *   $ lineman config concat.js #=> to see the JS config for the concat task.
@@ -33,7 +33,7 @@ module.exports = function(lineman) {
     // Sass
     //
     // Lineman supports Sass via grunt-contrib-sass, which requires you first
-    // have Ruby installed as well as the `sass` gem. To enable it, comment out the
+    // have Ruby installed as well as the `sass` gem. To enable it, uncomment the
     // following line:
     //
     // enableSass: false


### PR DESCRIPTION
Because we're in the context of a git repository, using the term 'check
out' to mean 'inspect' can be momentarily confusing.

In my experience 'comment out' means to take active code and put a
comment in front of it, effectively disabling it.
