### PR TITLE
use accessor from downstream changes in grunt-markdown-blog

### DIFF
--- a/app/templates/archive.us
+++ b/app/templates/archive.us
@@ -1,6 +1,6 @@
 <h1>archives</h1>
 <ul>
-<% _(site.posts).chain().reverse().each(function(post){ %>
+<% _(site.getPosts()).chain().reverse().each(function(post){ %>
   <li>
     <a href="/<%= post.htmlPath() %>"><%= post.title() %></a>
   </li>

--- a/app/templates/index.us
+++ b/app/templates/index.us
@@ -1,1 +1,1 @@
-<%= site.htmlFor(_(site.posts).last()) %>
+<%= site.htmlFor(_(site.getPosts()).last()) %>


### PR DESCRIPTION
- see https://github.com/testdouble/grunt-markdown-blog/pull/28/commits/96534b96c11c10e13aa404fb164749e77dbde124

Depends on https://github.com/testdouble/grunt-markdown-blog/pull/28 being shipped and a release published to npm first.